### PR TITLE
Implement trimmingCharacters from `FoundationEssentials`, prefer using `FoundationEssentials` over `Foundation`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # VSCode
 launch.json
+
+# Swiftly
+.swift-version

--- a/Sources/Systemd/Extensions/String+trimmingCharacters.swift
+++ b/Sources/Systemd/Extensions/String+trimmingCharacters.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+    // NOTE: This is copied from the FoundationEssentials module while we still don't
+    // have an official .trimmingCharacters method provided by FoundationEssentials.
+    // https://github.com/swiftlang/swift-foundation/tree/main/Sources/FoundationEssentials/String/BidirectionalCollection.swift#L37
+    func trimmingCharacters(while predicate: (Element) -> Bool) -> SubSequence {
+        var idx = startIndex
+        while idx < endIndex && predicate(self[idx]) {
+            formIndex(after: &idx)
+        }
+
+        let startOfNonTrimmedRange = idx  // Points at the first char not in the set
+        guard startOfNonTrimmedRange != endIndex else {
+            return self[endIndex...]
+        }
+
+        let beforeEnd = index(before: endIndex)
+        guard startOfNonTrimmedRange < beforeEnd else {
+            return self[startOfNonTrimmedRange..<endIndex]
+        }
+
+        var backIdx = beforeEnd
+        // No need to bound-check because we've already trimmed from the beginning, so we'd definitely break off of this loop before `backIdx` rewinds before `startIndex`
+        while predicate(self[backIdx]) {
+            formIndex(before: &backIdx)
+        }
+        return self[startOfNonTrimmedRange...backIdx]
+    }
+}

--- a/Sources/Systemd/SystemdHelpers.swift
+++ b/Sources/Systemd/SystemdHelpers.swift
@@ -1,4 +1,4 @@
-import Foundation
+import FoundationEssentials
 
 #if os(Linux)
     import CSystemd
@@ -57,8 +57,8 @@ public struct SystemdHelpers {
         #if os(Linux)
             let pid = Glibc.getppid()
             do {
-                let name = try String(contentsOfFile: "/proc/\(pid)/comm")
-                    .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                let name = try String(contentsOfFile: "/proc/\(pid)/comm", encoding: .utf8)
+                    .trimmingCharacters(while: \.isWhitespace)
                 return name == "systemd"
             } catch {
                 print("Unable to determine if running systemd: \(error)")

--- a/Sources/Systemd/SystemdHelpers.swift
+++ b/Sources/Systemd/SystemdHelpers.swift
@@ -1,4 +1,8 @@
-import FoundationEssentials
+#if canImport(FoundationEssentials)
+    import FoundationEssentials
+#else
+    import Foundation
+#endif
 
 #if os(Linux)
     import CSystemd
@@ -57,8 +61,13 @@ public struct SystemdHelpers {
         #if os(Linux)
             let pid = Glibc.getppid()
             do {
-                let name = try String(contentsOfFile: "/proc/\(pid)/comm", encoding: .utf8)
-                    .trimmingCharacters(while: \.isWhitespace)
+                #if canImport(FoundationEssentials)
+                    let name = try String(contentsOfFile: "/proc/\(pid)/comm", encoding: .utf8)
+                        .trimmingCharacters(while: \.isWhitespace)
+                #else
+                    let name = try String(contentsOfFile: "/proc/\(pid)/comm")
+                        .trimmingCharacters(in: CharacterSet.whitespaces)
+                #endif
                 return name == "systemd"
             } catch {
                 print("Unable to determine if running systemd: \(error)")


### PR DESCRIPTION
This fixes #4.

For now `trimmingCharacters` is not provided publicly by `FoundationEssentials`, but we copy it here and use it locally. 

If `FoundationEssentials` is not available, we still use `Foundation` on Swift before 6.x.